### PR TITLE
Form edits

### DIFF
--- a/language/fr.po
+++ b/language/fr.po
@@ -553,11 +553,11 @@ msgid "Total"
 msgstr "Total"
 
 #: src/Form/ReferenceFieldset.php:136
-msgid "Ascendant"
+msgid "Ascending"
 msgstr "Croissant"
 
 #: src/Form/ReferenceFieldset.php:137
-msgid "Descendant"
+msgid "Descending"
 msgstr "Décroissant"
 
 #: src/Form/ReferenceFieldset.php:155

--- a/src/Form/ReferenceFieldset.php
+++ b/src/Form/ReferenceFieldset.php
@@ -114,7 +114,7 @@ class ReferenceFieldset extends Fieldset
                 // 'type' => CommonElement\OptionalRadio::class,
                 'type' => Element\Select::class,
                 'options' => [
-                    'label' => 'Select order', // @translate
+                    'label' => 'Sort by', // @translate
                     'value_options' => [
                         'alphabetic' => 'Alphabetic',  // @translate
                         'total' => 'Total',  // @translate
@@ -131,10 +131,10 @@ class ReferenceFieldset extends Fieldset
                 // 'type' => CommonElement\OptionalRadio::class,
                 'type' => Element\Select::class,
                 'options' => [
-                    'label' => 'Select order', // @translate
+                    'label' => 'Sort order', // @translate
                     'value_options' => [
-                        'asc' => 'Ascendant',  // @translate
-                        'desc' => 'Descendant',  // @translate
+                        'asc' => 'Ascending',  // @translate
+                        'desc' => 'Descending',  // @translate
                     ],
                 ],
                 'attributes' => [


### PR DESCRIPTION
Changed duplicate "Select order" prompts for ordering terms and adjusted "Ascendant" and "Descendant" to "Ascending" and "Descending" to match default Omeka S form usage.